### PR TITLE
fixes the list of accounting software in sme_v5 and entity_v1

### DIFF
--- a/sme_finance_application_schema/entity_v1
+++ b/sme_finance_application_schema/entity_v1
@@ -234,9 +234,10 @@
                 "sage_live",
                 "sage_instant",
                 "sage_line_50",
-                "sage_other", 
-                "xero_quickbooks_online",
-                "xero_quickbooks_pro",
+                "sage_other",
+                "xero",
+                "quickbooks_online",
+                "quickbooks_pro",
                 "freeagent",
                 "spreadsheet",
                 "other"

--- a/sme_finance_application_schema/sme_v5
+++ b/sme_finance_application_schema/sme_v5
@@ -299,9 +299,10 @@
                 "sage_live",
                 "sage_instant",
                 "sage_line_50",
-                "sage_other", 
-                "xero_quickbooks_online",
-                "xero_quickbooks_pro",
+                "sage_other",
+                "xero",
+                "quickbooks_online",
+                "quickbooks_pro",
                 "freeagent",
                 "spreadsheet",
                 "other"


### PR DESCRIPTION
A compatibility-breaking fix that should be ok because nobody outside Funding Options is using entity_v1 or sme_v5