### PR TITLE
adds sets_of_filed_accounts

### DIFF
--- a/examples.py
+++ b/examples.py
@@ -39,7 +39,7 @@ SME_V5 = {
     'up_to_date_accounts':True,
     'count_of_invoiced_customers': 100,
     'outstanding_invoices': 1000,
-    'years_of_filed_accounts': 10,
+    'sets_of_filed_accounts': 10,
 }
 
 SME_CONTACT_V3 = {
@@ -139,7 +139,7 @@ ENTITY_V1 = {
         'address': ADDRESS_V1,
     }],
     'free_form': 'A string',
-    'years_of_filed_accounts': 10,
+    'sets_of_filed_accounts': 10,
 }
 
 ACTOR_V1_DIRECTOR_1 = {

--- a/examples.py
+++ b/examples.py
@@ -39,6 +39,7 @@ SME_V5 = {
     'up_to_date_accounts':True,
     'count_of_invoiced_customers': 100,
     'outstanding_invoices': 1000,
+    'years_of_filed_accounts': 10,
 }
 
 SME_CONTACT_V3 = {
@@ -138,6 +139,7 @@ ENTITY_V1 = {
         'address': ADDRESS_V1,
     }],
     'free_form': 'A string',
+    'years_of_filed_accounts': 10,
 }
 
 ACTOR_V1_DIRECTOR_1 = {

--- a/sme_finance_application_schema/entity_v1
+++ b/sme_finance_application_schema/entity_v1
@@ -247,9 +247,9 @@
             "description": "The sum of the value of all unsatisfied County Court Judgements (CCJs) against the SME, in GBP",
             "type": "integer"
         },
-        "years_of_filed_accounts": {
-            "title": "How many years of consecutive accounts the SME has filed",
-            "description": "Starting with the most recent set of filed accounts, the number of consecutive years of accounts the SME has filed",
+        "sets_of_filed_accounts": {
+            "title": "How many sets of accounts the SME has filed",
+            "description": "The number of sets of accounts the SME has filed with Companies House",
             "type": "integer"
         }
     }

--- a/sme_finance_application_schema/entity_v1
+++ b/sme_finance_application_schema/entity_v1
@@ -246,6 +246,11 @@
             "title": "Total value of unsatisfied CCJs",
             "description": "The sum of the value of all unsatisfied County Court Judgements (CCJs) against the SME, in GBP",
             "type": "integer"
+        },
+        "years_of_filed_accounts": {
+            "title": "How many years of consecutive accounts the SME has filed",
+            "description": "Starting with the most recent set of filed accounts, the number of consecutive years of accounts the SME has filed",
+            "type": "integer"
         }
     }
 }

--- a/sme_finance_application_schema/sme_v5
+++ b/sme_finance_application_schema/sme_v5
@@ -323,9 +323,9 @@
             "description": "The number of customers that the SME bills by invoice",
             "type": "integer"
         },
-        "years_of_filed_accounts": {
-            "title": "How many years of consecutive accounts the SME has filed",
-            "description": "Starting with the most recent set of filed accounts, the number of consecutive years of accounts the SME has filed",
+        "sets_of_filed_accounts": {
+            "title": "How many sets of accounts the SME has filed",
+            "description": "The number of sets of accounts the SME has filed with Companies House",
             "type": "integer"
         }
     }

--- a/sme_finance_application_schema/sme_v5
+++ b/sme_finance_application_schema/sme_v5
@@ -322,6 +322,11 @@
             "title": "How many customers the SME invoices",
             "description": "The number of customers that the SME bills by invoice",
             "type": "integer"
+        },
+        "years_of_filed_accounts": {
+            "title": "How many years of consecutive accounts the SME has filed",
+            "description": "Starting with the most recent set of filed accounts, the number of consecutive years of accounts the SME has filed",
+            "type": "integer"
         }
     }
 }

--- a/sme_finance_application_schema/translations.py
+++ b/sme_finance_application_schema/translations.py
@@ -33,7 +33,7 @@ def finance_application_v3_to_sme_v5(finance_application):
                   'business_plan', 'card_revenue', 'online_revenue', 'institutional_revenue',
                   'stock_ready', 'revenue_growth', 'intellectual_property', 'trade_credit',
                   'business_premises', 'registered_brand', 'customers', 'region',
-                  'company_credit_rating', 'accounting_software',
+                  'company_credit_rating', 'accounting_software', 'years_of_filed_accounts',
                   'total_value_of_unsatisfied_ccjs', 'count_of_invoiced_customers', 'outstanding_invoices'):
         if field in finance_application['requesting_entity']:
             sme_v5[field] = finance_application['requesting_entity'][field]
@@ -131,6 +131,7 @@ def sme_v5_and_contact_v3_to_requesting_entity_v1_translator(sme, sme_contact):
         'total_value_of_unsatisfied_ccjs': sme.get('total_value_of_unsatisfied_ccjs'),
         'outstanding_invoices': sme.get('outstanding_invoices'),
         'count_of_invoiced_customers': sme.get('count_of_invoiced_customers'),
+        'years_of_filed_accounts': sme.get('years_of_filed_accounts'),
     }
     return _remove_key_if_value_is_none(requesting_entity)
 

--- a/sme_finance_application_schema/translations.py
+++ b/sme_finance_application_schema/translations.py
@@ -33,7 +33,7 @@ def finance_application_v3_to_sme_v5(finance_application):
                   'business_plan', 'card_revenue', 'online_revenue', 'institutional_revenue',
                   'stock_ready', 'revenue_growth', 'intellectual_property', 'trade_credit',
                   'business_premises', 'registered_brand', 'customers', 'region',
-                  'company_credit_rating', 'accounting_software', 'years_of_filed_accounts',
+                  'company_credit_rating', 'accounting_software', 'sets_of_filed_accounts',
                   'total_value_of_unsatisfied_ccjs', 'count_of_invoiced_customers', 'outstanding_invoices'):
         if field in finance_application['requesting_entity']:
             sme_v5[field] = finance_application['requesting_entity'][field]
@@ -131,7 +131,7 @@ def sme_v5_and_contact_v3_to_requesting_entity_v1_translator(sme, sme_contact):
         'total_value_of_unsatisfied_ccjs': sme.get('total_value_of_unsatisfied_ccjs'),
         'outstanding_invoices': sme.get('outstanding_invoices'),
         'count_of_invoiced_customers': sme.get('count_of_invoiced_customers'),
-        'years_of_filed_accounts': sme.get('years_of_filed_accounts'),
+        'sets_of_filed_accounts': sme.get('sets_of_filed_accounts'),
     }
     return _remove_key_if_value_is_none(requesting_entity)
 


### PR DESCRIPTION
https://app.clubhouse.io/fundingoptions/story/3223/add-years-of-filed-accounts-to-matching-engine

@tompittsFO  Can you check the description of this field - this is just for the schema so needs to be as raw and accurate a description of the data to be stored as possible. I believe that the requirement for "consecutive years, starting with the current year" is what we actually need to do the matching, rather than "count of sets of accounts" or "date first accounts filed", as lenders are interested in the length of accounting history, correct?

We also need to think about what we say on our forms, but that's going to be a separate PR