### PR TITLE
introduce requirements for certain fields related to roles and addresses

### DIFF
--- a/sme_finance_application_schema/actor_v1
+++ b/sme_finance_application_schema/actor_v1
@@ -5,6 +5,9 @@
     "description": "An actor is a person acting in the capacity of director or guarantor",
     "additionalProperties": false,
     "type": "object",
+    "required": [
+        "role"
+    ],
     "properties": {
         "value_of_personal_assets": {
             "title": "Value of personal assets",

--- a/sme_finance_application_schema/entity_v1
+++ b/sme_finance_application_schema/entity_v1
@@ -23,6 +23,10 @@
             "type": "array",
             "items": {
                 "type": "object",
+                "required": [
+                    "address",
+                    "role"
+                ],
                 "properties": {
                     "address": {"$ref": "address_v1"},
                     "role": {

--- a/sme_finance_application_schema/person_v1
+++ b/sme_finance_application_schema/person_v1
@@ -26,6 +26,7 @@
             "description": "The person's primary residences",
             "items": {
                 "type": "object",
+                "required": ["address"],
                 "properties": {
                     "address": {"$ref": "address_v1"},
                     "from": {


### PR DESCRIPTION
Internally, we've always required these fields.
To ensure compatibility in the future, we need to require address/actor roles at a lower level.