### PR TITLE
Refurbish(e)ment typo was causing schema validation failures

### DIFF
--- a/sme_finance_application_schema/finance_need_v1
+++ b/sme_finance_application_schema/finance_need_v1
@@ -66,8 +66,8 @@
             "type": "string",
             "enum": [
                 "none",
-                "refurbishement_and_sale",
-                "refurbishement_and_let",
+                "refurbishment_and_sale",
+                "refurbishment_and_let",
                 "ground_up_development_single_unit",
                 "ground_up_development_multiple_units"
             ]

--- a/sme_finance_application_schema/tests/fixtures.py
+++ b/sme_finance_application_schema/tests/fixtures.py
@@ -93,7 +93,7 @@ FINANCE_NEED_V1 = {
     'property_work_started': 'yes',
     'asset_type': 'Another string',
     'type_of_mortgage': 'commercial_buy_to_let',
-    'experience_in_development': 'refurbishement_and_sale',
+    'experience_in_development': 'refurbishment_and_sale',
     'deposit': 50000,
     'vehicle_type': 'Apache helicopter',
     'type_of_property': 'undeveloped_land_with_planning_permission',


### PR DESCRIPTION
Le sigh...

This is a) daft and b) causes failures on staff application schema validation when customers have selected a correctly spelled choice on the website.