### PR TITLE
Extending the translators with code from Funding Options main repo

### DIFF
--- a/sme_finance_application_schema/tests/fixtures.py
+++ b/sme_finance_application_schema/tests/fixtures.py
@@ -1,6 +1,6 @@
 import copy
 
-SME_V5 = {
+SME_V3 = {
     'legal_status': 'limited_company',
     'finance_term_length': 30,
     'purpose': 'stock',
@@ -11,16 +11,12 @@ SME_V5 = {
     'trade_credit': 0,
     'revenue': 2000,
     'sic_code': 'A',
-    'card_revenue':3000,
+    'card_revenue':50,
     'financial_forecast':True,
     'finance_type_requested':'term_loan',
     'revenue_growth':50,
-    'purchase_orders':50,
-    'guarantor_available':True,
     'directors_pensions':60000,
     'registered_brand':True,
-    'familiarity_with_financing':'expert',
-    'stock_imports':50,
     'customers':100,
     'business_plan':True,
     'stock_ready':50,
@@ -28,14 +24,36 @@ SME_V5 = {
     'business_assets':30000,
     'region':'UKZ',
     'intellectual_property':True,
-    'accounting_software':'xero',
     'overseas_revenue':50,
     'online_revenue':50,
+    'directors_houses':60000,
+    'profitability':50,
+    'institutional_revenue':50,
+    'up_to_date_accounts':True,
+    'finance_term_general': 'long_term_investing',
+    'company_number': '123456',
+}
+
+SME_V3_MISSING_INFORMATION = copy.deepcopy(SME_V3)
+for missing_field in ['requested_amount']:
+    SME_V3_MISSING_INFORMATION.pop(missing_field)
+
+# company_number and finance_term_general not present on v5
+# card_revenue is now a value rather than percentage
+
+SME_V5 = copy.deepcopy(SME_V3)
+SME_V5.pop('company_number')
+SME_V5.pop('finance_term_general')
+SME_V5.update({
+    'card_revenue':1000,
+    'purchase_orders':50,
+    'guarantor_available':True,
+    'familiarity_with_financing':'expert',
+    'stock_imports':50,
+    'accounting_software':'xero',
     'company_credit_rating':'ok',
     'personal_credit_ratings':'poor',
-    'directors_houses':60000,
     'exports':True,
-    'total_value_of_unsatisfied_ccjs':1000,
     'profitability':50,
     'institutional_revenue':50,
     'up_to_date_accounts':True,
@@ -44,9 +62,10 @@ SME_V5 = {
     'sets_of_filed_accounts': 10,
     'count_of_unsatisfied_ccjs': 1,
     'count_of_all_ccjs': 3,
-}
+    'total_value_of_unsatisfied_ccjs':1000,
+})
 
-SME_CONTACT_V3 = {
+SME_CONTACT_V2 = {
     'applicant_title': 'Mr',
     'applicant_first_name': 'Dave',
     'applicant_surname': 'dd',
@@ -60,6 +79,12 @@ SME_CONTACT_V3 = {
     'city': 'London',
     'county': 'London',
 }
+
+SME_CONTACT_V3 = copy.deepcopy(SME_CONTACT_V2)
+
+SME_CONTACT_V2_MISSING_INFORMATION = copy.deepcopy(SME_CONTACT_V2)
+for missing_field in ['sme_name', 'applicant_first_name', 'applicant_surname']:
+    SME_CONTACT_V2_MISSING_INFORMATION.pop(missing_field)
 
 ADDRESS_V1 = {
     'building_number_and_street_name': '30 Great Guildford Street',
@@ -109,7 +134,7 @@ ENTITY_V1 = {
     'trade_credit':0,
     'revenue':2000,
     'sic_code':'A',
-    'card_revenue':3000,
+    'card_revenue':1000,
     'financial_forecast':True,
     'revenue_growth':50,
     'purchase_orders':50,
@@ -194,7 +219,7 @@ AGGREGATED_ACTORS_V1 = {
 AGGREGATED_ACTORS_V1_INCOMPLETE = {
     'sum_value_of_property_equity': 10000,
     'sum_value_of_pension': 1000000,
-    'max_familiarity_with_financing': 'ok',
+    'max_familiarity_with_financing': 'expert',
     'min_personal_credit_rating': 'excellent',
 }
 

--- a/sme_finance_application_schema/tests/test.py
+++ b/sme_finance_application_schema/tests/test.py
@@ -7,7 +7,11 @@ from unittest import TestCase
 
 
 from .fixtures import (
+    SME_V3,
+    SME_V3_MISSING_INFORMATION,
     SME_V5,
+    SME_CONTACT_V2,
+    SME_CONTACT_V2_MISSING_INFORMATION,
     SME_CONTACT_V3,
     ADDRESS_V1,
     PERSON_V1,
@@ -17,12 +21,16 @@ from .fixtures import (
     ACTOR_V1_DIRECTOR_2,
     ACTOR_V1_GUARANTOR,
     FINANCE_APPLICATION_V3,
+    AGGREGATED_ACTORS_V1,
+    AGGREGATED_ACTORS_V1_INCOMPLETE,
     FINANCE_APPLICATION_V3_AGGREGATED_INCOMPLETE,
 )
 from sme_finance_application_schema.translations import (
     sme_v5_and_contact_v3_to_finance_application_v3_translator,
     finance_application_v3_to_sme_v5,
     finance_application_v3_to_sme_contact_v3,
+    sme_v3_and_contact_v2_to_finance_application_v3_translator,
+    sme_contact_v2_to_person_v1_translator,
 )
 
 
@@ -34,23 +42,75 @@ UNTRANSLATED_CONTACT_V3_FIELDS = [
 ]
 
 
+# The following are fields that do not appear in the objects when they are translated from sme_v3 / sme_contact_v2
+UNTRANSLATED_FROM_SME_V3_CONTACT_V2_TO_ENTITY_V1_FIELDS = [
+    # Not present in SME_V3
+    'employees',
+    'registration_date',
+    'addresses',
+    'free_form',
+    'accounting_software',
+    'company_credit_rating',
+    'count_of_all_ccjs',
+    'count_of_invoiced_customers',
+    'count_of_unsatisfied_ccjs',
+    'exports',
+    'outstanding_invoices',
+    'purchase_orders',
+    'sets_of_filed_accounts',
+    'stock_imports',
+    'total_value_of_unsatisfied_ccjs',
+]
+UNTRANSLATED_FROM_SME_V3_CONTACT_V2_TO_FINANCE_APPLICATION_V3_FIELDS = [
+    # Unsupported
+    'actors',
+]
+UNTRANSLATED_FROM_SME_V3_CONTACT_V2_TO_PERSON_V1_FIELDS = [
+    # Not present in SME_V3 or CONTACT_V2
+    'date_of_birth'
+]
+UNTRANSLATED_FROM_SME_V3_CONTACT_V2_TO_FINANCE_NEED_V1_FIELDS = [
+    # Not present in SME_V3
+    'free_form',
+    'property_ownership',
+    'permission_for_development',
+    'property_development_type',
+    'property_work_started',
+    'asset_type',
+    'type_of_mortgage',
+    'experience_in_development',
+    'deposit',
+    'vehicle_type',
+    'type_of_property',
+    'guarantor_available'
+]
+UNTRANSLATED_FROM_SME_V3_CONTACT_V2_TO_ADDRESS_V1_FIELDS = []
+UNTRANSLATED_FROM_SME_V3_CONTACT_V2_TO_AGGREGATED_ACTORS_V1_FIELDS = [
+    # Cannot generate from SME_V3
+    'max_personal_credit_rating',
+    'sum_outstanding_mortgage_on_property',
+    'max_familiarity_with_financing',
+    'min_personal_credit_rating',
+]
+
+
 # The following are fields that do not appear in the objects when they are translated from sme_v5 / sme_contact_v3
-UNTRANSLATED_ENTITY_V1_FIELDS = [
+UNTRANSLATED_FROM_SME_V5_CONTACT_V3_TO_ENTITY_V1_FIELDS = [
     # Not present in SME_V5
     'employees',
     'registration_date',
     'addresses',
     'free_form',
 ]
-UNTRANSLATED_FINANCE_APPLICATION_V3_FIELDS = [
+UNTRANSLATED_FROM_SME_V5_CONTACT_V3_TO_FINANCE_APPLICATION_V3_FIELDS = [
     # Unsupported
     'actors',
 ]
-UNTRANSLATED_PERSON_V1_FIELDS = [
+UNTRANSLATED_FROM_SME_V5_CONTACT_V3_TO_PERSON_V1_FIELDS = [
     # Not present in SME_V5 or CONTACT_V3
     'date_of_birth'
 ]
-UNTRANSLATED_FINANCE_NEED_V1_FIELDS = [
+UNTRANSLATED_FROM_SME_V5_CONTACT_V3_TO_FINANCE_NEED_V1_FIELDS = [
     # Not present in SME_V5
     'free_form',
     'property_ownership',
@@ -64,8 +124,8 @@ UNTRANSLATED_FINANCE_NEED_V1_FIELDS = [
     'vehicle_type',
     'type_of_property',
 ]
-UNTRANSLATED_ADDRESS_V1_FIELDS = []
-UNTRANSLATED_AGGREGATED_ACTORS_V1_FIELDS = [
+UNTRANSLATED_FROM_SME_V5_CONTACT_V3_TO_ADDRESS_V1_FIELDS = []
+UNTRANSLATED_FROM_SME_V5_CONTACT_V3_TO_AGGREGATED_ACTORS_V1_FIELDS = [
     # Cannot generate from SME_v5
     'max_personal_credit_rating',
     'sum_outstanding_mortgage_on_property',
@@ -117,9 +177,14 @@ class TestSampleData(TestCase):
 
 
     def test_sample_data_is_valid(self):
+        self.validity_of_data_subtest(SME_V3,'sme_v3')
+        self.validity_of_data_subtest(SME_V3_MISSING_INFORMATION,'sme_v3')
+        self.validity_of_data_subtest(SME_CONTACT_V2,'sme_contact_v2')
+        self.validity_of_data_subtest(SME_CONTACT_V2_MISSING_INFORMATION,'sme_contact_v2')
         self.validity_of_data_subtest(SME_V5,'sme_v5')
         self.validity_of_data_subtest(SME_CONTACT_V3,'sme_contact_v3')
         self.validity_of_data_subtest(FINANCE_APPLICATION_V3,'finance_application_v3')
+        self.validity_of_data_subtest(FINANCE_APPLICATION_V3_AGGREGATED_INCOMPLETE,'finance_application_v3')
         self.validity_of_data_subtest(FINANCE_NEED_V1,'finance_need_v1')
         self.validity_of_data_subtest(ENTITY_V1,'entity_v1')
         self.validity_of_data_subtest(PERSON_V1,'person_v1')
@@ -127,9 +192,13 @@ class TestSampleData(TestCase):
         self.validity_of_data_subtest(ACTOR_V1_DIRECTOR_1,'actor_v1')
         self.validity_of_data_subtest(ACTOR_V1_DIRECTOR_2,'actor_v1')
         self.validity_of_data_subtest(ACTOR_V1_GUARANTOR,'actor_v1')
+        self.validity_of_data_subtest(AGGREGATED_ACTORS_V1,'aggregated_actors_v1')
+        self.validity_of_data_subtest(AGGREGATED_ACTORS_V1_INCOMPLETE,'aggregated_actors_v1')
 
 
     def test_sample_data_is_complete(self):
+        self.completion_of_data_subtest(SME_V3,'sme_v3')
+        self.completion_of_data_subtest(SME_CONTACT_V2,'sme_contact_v2')
         self.completion_of_data_subtest(SME_V5,'sme_v5')
         self.completion_of_data_subtest(SME_CONTACT_V3,'sme_contact_v3')
         self.completion_of_data_subtest(FINANCE_APPLICATION_V3,'finance_application_v3')
@@ -140,27 +209,44 @@ class TestSampleData(TestCase):
         self.completion_of_data_subtest(ACTOR_V1_DIRECTOR_1,'actor_v1')
         self.completion_of_data_subtest(ACTOR_V1_DIRECTOR_2,'actor_v1')
         self.completion_of_data_subtest(ACTOR_V1_GUARANTOR,'actor_v1')
+        self.completion_of_data_subtest(AGGREGATED_ACTORS_V1,'aggregated_actors_v1')
         # TODO - test entity_address and actor_address structures
 
 
 class TestTranslations(TestCase):
-    def test_sme_v5_and_contact_v3_to_finance_application_v3(self):
-        expected_finance_application_v3 = copy.deepcopy(FINANCE_APPLICATION_V3)
-        for field in UNTRANSLATED_FINANCE_APPLICATION_V3_FIELDS:
-            expected_finance_application_v3.pop(field)
-        for field in UNTRANSLATED_ENTITY_V1_FIELDS:
-            expected_finance_application_v3['requesting_entity'].pop(field)
-        for field in UNTRANSLATED_PERSON_V1_FIELDS:
-            expected_finance_application_v3['applicant'].pop(field)
-        for field in UNTRANSLATED_FINANCE_NEED_V1_FIELDS:
-            expected_finance_application_v3['finance_need'].pop(field)
-        for field in UNTRANSLATED_ADDRESS_V1_FIELDS:
-            expected_finance_application_v3['applicant']['addresses'][0]['address'].pop(field)
-        for field in UNTRANSLATED_AGGREGATED_ACTORS_V1_FIELDS:
-            expected_finance_application_v3['aggregated_actors'].pop(field)
+    def setUp(self):
+        self.expected_finance_application_v3_from_sme_v3_and_contact_v2 = copy.deepcopy(FINANCE_APPLICATION_V3)
+        for field in UNTRANSLATED_FROM_SME_V3_CONTACT_V2_TO_FINANCE_APPLICATION_V3_FIELDS:
+            self.expected_finance_application_v3_from_sme_v3_and_contact_v2.pop(field)
+        for field in UNTRANSLATED_FROM_SME_V3_CONTACT_V2_TO_ENTITY_V1_FIELDS:
+            self.expected_finance_application_v3_from_sme_v3_and_contact_v2['requesting_entity'].pop(field)
+        for field in UNTRANSLATED_FROM_SME_V3_CONTACT_V2_TO_PERSON_V1_FIELDS:
+            self.expected_finance_application_v3_from_sme_v3_and_contact_v2['applicant'].pop(field)
+        for field in UNTRANSLATED_FROM_SME_V3_CONTACT_V2_TO_FINANCE_NEED_V1_FIELDS:
+            self.expected_finance_application_v3_from_sme_v3_and_contact_v2['finance_need'].pop(field)
+        for field in UNTRANSLATED_FROM_SME_V3_CONTACT_V2_TO_ADDRESS_V1_FIELDS:
+            self.expected_finance_application_v3_from_sme_v3_and_contact_v2['applicant']['addresses'][0]['address'].pop(field)
+        for field in UNTRANSLATED_FROM_SME_V3_CONTACT_V2_TO_AGGREGATED_ACTORS_V1_FIELDS:
+            self.expected_finance_application_v3_from_sme_v3_and_contact_v2['aggregated_actors'].pop(field)
 
+        self.expected_finance_application_v3_from_sme_v5_and_contact_v3 = copy.deepcopy(FINANCE_APPLICATION_V3)
+        for field in UNTRANSLATED_FROM_SME_V5_CONTACT_V3_TO_FINANCE_APPLICATION_V3_FIELDS:
+            self.expected_finance_application_v3_from_sme_v5_and_contact_v3.pop(field)
+        for field in UNTRANSLATED_FROM_SME_V5_CONTACT_V3_TO_ENTITY_V1_FIELDS:
+            self.expected_finance_application_v3_from_sme_v5_and_contact_v3['requesting_entity'].pop(field)
+        for field in UNTRANSLATED_FROM_SME_V5_CONTACT_V3_TO_PERSON_V1_FIELDS:
+            self.expected_finance_application_v3_from_sme_v5_and_contact_v3['applicant'].pop(field)
+        for field in UNTRANSLATED_FROM_SME_V5_CONTACT_V3_TO_FINANCE_NEED_V1_FIELDS:
+            self.expected_finance_application_v3_from_sme_v5_and_contact_v3['finance_need'].pop(field)
+        for field in UNTRANSLATED_FROM_SME_V5_CONTACT_V3_TO_ADDRESS_V1_FIELDS:
+            self.expected_finance_application_v3_from_sme_v5_and_contact_v3['applicant']['addresses'][0]['address'].pop(field)
+        for field in UNTRANSLATED_FROM_SME_V5_CONTACT_V3_TO_AGGREGATED_ACTORS_V1_FIELDS:
+            self.expected_finance_application_v3_from_sme_v5_and_contact_v3['aggregated_actors'].pop(field)
+
+
+    def test_sme_v5_and_contact_v3_to_finance_application_v3(self):
         translated_finance_application_v3 = sme_v5_and_contact_v3_to_finance_application_v3_translator(SME_V5, SME_CONTACT_V3)
-        self.assertDictEqual(translated_finance_application_v3, expected_finance_application_v3)
+        self.assertDictEqual(translated_finance_application_v3, self.expected_finance_application_v3_from_sme_v5_and_contact_v3)
 
 
     def test_finance_application_v3_to_sme_v5(self):
@@ -174,7 +260,7 @@ class TestTranslations(TestCase):
     def test_finance_application_v3_to_sme_v5_partial_aggregated(self):
         expected_sme_v5 = copy.deepcopy(SME_V5)
         expected_sme_v5.update({
-            'familiarity_with_financing': 'ok',
+            'familiarity_with_financing': 'expert',
         })
         self.maxDiff=None
         translated_sme_v5 = finance_application_v3_to_sme_v5(FINANCE_APPLICATION_V3_AGGREGATED_INCOMPLETE)
@@ -188,3 +274,58 @@ class TestTranslations(TestCase):
 
         translated_sme_contact_v3 = finance_application_v3_to_sme_contact_v3(FINANCE_APPLICATION_V3)
         self.assertDictEqual(translated_sme_contact_v3, expected_sme_contact_v3)
+
+
+    def test_sme_v3_and_contact_v2_to_finance_application_v3_no_backfill(self):
+        translated_finance_application_v3 = sme_v3_and_contact_v2_to_finance_application_v3_translator(SME_V3, SME_CONTACT_V2)
+        self.assertDictEqual(translated_finance_application_v3, self.expected_finance_application_v3_from_sme_v3_and_contact_v2)
+
+
+    def test_sme_v3_and_contact_v2_to_finance_application_v3_with_backfill(self):
+        translated_finance_application_v3 = sme_v3_and_contact_v2_to_finance_application_v3_translator(SME_V3_MISSING_INFORMATION, SME_CONTACT_V2_MISSING_INFORMATION)
+        with self.assertRaises(AssertionError):
+            self.assertDictEqual(translated_finance_application_v3, self.expected_finance_application_v3_from_sme_v3_and_contact_v2)
+
+        expected_finance_application_v3 = copy.deepcopy(self.expected_finance_application_v3_from_sme_v3_and_contact_v2)
+        expected_finance_application_v3['requesting_entity']['name'] = 'Unknown'
+        expected_finance_application_v3['finance_need']['requested_amount'] = 0
+        expected_finance_application_v3['applicant']['first_name'] = 'Unknown'
+        expected_finance_application_v3['applicant']['surname'] = 'Unknown'
+
+        translated_finance_application_v3 = sme_v3_and_contact_v2_to_finance_application_v3_translator(SME_V3_MISSING_INFORMATION, SME_CONTACT_V2_MISSING_INFORMATION, backfill_required_properties=True)
+        self.assertDictEqual(translated_finance_application_v3, expected_finance_application_v3)
+
+
+    def test_sme_v3_and_contact_v2_to_finance_application_v3_incorrect_months_revenue(self):
+        sme_v3_with_incorrect_months_revenue = copy.deepcopy(SME_V3)
+        sme_v3_with_incorrect_months_revenue.update({'months_revenue': 2000})
+        expected_finance_application_v3 = copy.deepcopy(self.expected_finance_application_v3_from_sme_v3_and_contact_v2)
+        expected_finance_application_v3['requesting_entity']['months_revenue'] = 1800
+        translated_finance_application_v3 = sme_v3_and_contact_v2_to_finance_application_v3_translator(sme_v3_with_incorrect_months_revenue, SME_CONTACT_V2)
+        self.assertDictEqual(translated_finance_application_v3, expected_finance_application_v3)
+
+
+    def test_sme_v3_and_contact_v2_to_finance_application_v3_incorrect_legal_status(self):
+        legal_status_mapping = {
+            'partnership_less_than_5': 'partnership_less_than_equal_to_3',
+            'partnership_more_than_4': 'partnership_greater_than_3'
+        }
+        for original_value, new_value in legal_status_mapping.items():
+            with self.subTest(original_value=original_value, new_value=new_value):
+                sme_v3_with_incorrect_legal_status = copy.deepcopy(SME_V3)
+                sme_v3_with_incorrect_legal_status.update({'legal_status': original_value})
+                expected_finance_application_v3 = copy.deepcopy(self.expected_finance_application_v3_from_sme_v3_and_contact_v2)
+                expected_finance_application_v3['requesting_entity']['legal_status'] = new_value
+                translated_finance_application_v3 = sme_v3_and_contact_v2_to_finance_application_v3_translator(sme_v3_with_incorrect_legal_status, SME_CONTACT_V2)
+                self.assertDictEqual(translated_finance_application_v3, expected_finance_application_v3)
+
+
+    def test_sme_contact_v2_to_person_v1_translator(self):
+        sme_contact_v2_with_normal_phone_number = copy.deepcopy(SME_CONTACT_V2)
+        sme_contact_v2_with_normal_phone_number['telephone'] = '07445387241'
+        person_v1 = sme_contact_v2_to_person_v1_translator(sme_contact_v2_with_normal_phone_number)
+        expected_person_v1 = copy.deepcopy(PERSON_V1)
+        for field in UNTRANSLATED_FROM_SME_V3_CONTACT_V2_TO_PERSON_V1_FIELDS:
+            expected_person_v1.pop(field)
+        expected_person_v1['telephone'] = '7445387241'
+        self.assertDictEqual(person_v1, expected_person_v1)

--- a/sme_finance_application_schema/translations.py
+++ b/sme_finance_application_schema/translations.py
@@ -190,8 +190,8 @@ def sme_contact_v3_to_address_v1_translator(sme_contact):
 def sme_contact_v3_to_person_v1_translator(sme_contact):
     person = {
         'title': sme_contact.get('applicant_title'),
-        'first_name': sme_contact.get('applicant_first_name') or '',
-        'surname': sme_contact.get('applicant_surname') or '',
+        'first_name': sme_contact.get('applicant_first_name'),
+        'surname': sme_contact.get('applicant_surname'),
         'email': sme_contact.get('email'),
         'telephone': sme_contact.get('telephone')
     }

--- a/sme_finance_application_schema/translations.py
+++ b/sme_finance_application_schema/translations.py
@@ -1,3 +1,5 @@
+import re
+
 def finance_application_v3_to_sme_contact_v3(finance_application):
     applicant = finance_application['applicant']
     requesting_entity = finance_application['requesting_entity']
@@ -113,7 +115,20 @@ def sme_v5_and_contact_v3_to_finance_application_v3_translator(sme, sme_contact)
     })
 
 
-def sme_v5_and_contact_v3_to_requesting_entity_v1_translator(sme, sme_contact):
+def sme_v3_and_contact_v2_to_finance_application_v3_translator(sme, sme_contact, backfill_required_properties=False):
+    applicant = sme_contact_v2_to_person_v1_translator(sme_contact, backfill_required_properties=backfill_required_properties)
+    requesting_entity = sme_v3_and_contact_v2_to_requesting_entity_v1_translator(sme, sme_contact, backfill_required_properties=backfill_required_properties)
+    finance_need = sme_v3_to_finance_need_v1_translator(sme, backfill_required_properties=backfill_required_properties)
+    aggregated_actors = sme_v3_to_aggregated_actors_v1_translator(sme)
+    return _remove_key_if_value_is_none({
+        'applicant': applicant,
+        'requesting_entity': requesting_entity,
+        'finance_need': finance_need,
+        'aggregated_actors': aggregated_actors or None,
+    })
+
+
+def sme_v3_and_contact_v2_to_requesting_entity_v1_translator(sme, sme_contact, backfill_required_properties=False):
     requesting_entity = {
         'name': sme_contact.get('sme_name'),
         'company_number': sme_contact.get('company_number'),
@@ -124,9 +139,6 @@ def sme_v5_and_contact_v3_to_requesting_entity_v1_translator(sme, sme_contact):
         'profitability': sme.get('profitability'),
         'business_assets': sme.get('business_assets'),
         'overseas_revenue': sme.get('overseas_revenue'),
-        'exports': sme.get('exports'),
-        'stock_imports': sme.get('stock_imports'),
-        'purchase_orders': sme.get('purchase_orders'),
         'up_to_date_accounts': sme.get('up_to_date_accounts'),
         'financial_forecast': sme.get('financial_forecast'),
         'business_plan': sme.get('business_plan'),
@@ -141,6 +153,42 @@ def sme_v5_and_contact_v3_to_requesting_entity_v1_translator(sme, sme_contact):
         'registered_brand': sme.get('registered_brand'),
         'customers': sme.get('customers'),
         'region': sme.get('region'),
+    }
+    requesting_entity = _remove_key_if_value_is_none(requesting_entity)
+    if backfill_required_properties:
+        requesting_entity = _backfill_required_properties(requesting_entity, {'name': 'Unknown', 'months_revenue': 0})
+
+    # sme_v3 expresses card_revenue as a percentage, entity_v1 as a value
+    card_revenue_as_percentage = requesting_entity.get('card_revenue')
+    revenue = requesting_entity.get('revenue')
+    if card_revenue_as_percentage and revenue:
+        card_revenue_as_value = round(revenue*(card_revenue_as_percentage/100))
+        requesting_entity['card_revenue'] = card_revenue_as_value
+    elif card_revenue_as_percentage:
+        # If we can't work it out, discard it
+        requesting_entity.pop('card_revenue')
+
+    # sme_v3 doesnt have a limit on months_revenue, entity_v1 does
+    if int(requesting_entity.get('months_revenue', 0)) > 1800:
+        requesting_entity['months_revenue'] = 1800
+
+    # sme_v3 has an error in the partnership sizes
+    if requesting_entity.get('legal_status') == 'partnership_less_than_5':
+        requesting_entity['legal_status'] = 'partnership_less_than_equal_to_3'
+    elif requesting_entity.get('legal_status') == 'partnership_more_than_4':
+        requesting_entity['legal_status'] = 'partnership_greater_than_3'
+
+    return requesting_entity
+
+
+def sme_v5_and_contact_v3_to_requesting_entity_v1_translator(sme, sme_contact):
+    # sme_v5 has additional properties to v3
+    # sme_contact_v3 has different requirements to v2
+    requesting_entity = sme_v3_and_contact_v2_to_requesting_entity_v1_translator(sme, sme_contact)
+    additional_data_from_sme_v5 = {
+        'exports': sme.get('exports'),
+        'stock_imports': sme.get('stock_imports'),
+        'purchase_orders': sme.get('purchase_orders'),
         'company_credit_rating': sme.get('company_credit_rating'),
         'accounting_software': sme.get('accounting_software'),
         'total_value_of_unsatisfied_ccjs': sme.get('total_value_of_unsatisfied_ccjs'),
@@ -149,31 +197,55 @@ def sme_v5_and_contact_v3_to_requesting_entity_v1_translator(sme, sme_contact):
         'sets_of_filed_accounts': sme.get('sets_of_filed_accounts'),
         'count_of_all_ccjs': sme.get('count_of_all_ccjs'),
         'count_of_unsatisfied_ccjs': sme.get('count_of_unsatisfied_ccjs'),
+        # Overwrite the card revenue provided by the sme_v3 translator since sme_v5 provides as a value
+        'card_revenue': sme.get('card_revenue'),
     }
+    requesting_entity.update(additional_data_from_sme_v5)
     return _remove_key_if_value_is_none(requesting_entity)
 
 
-def sme_v5_to_finance_need_v1_translator(sme):
+def sme_v3_to_finance_need_v1_translator(sme, backfill_required_properties=False):
     finance_need = {
         'requested_amount': sme.get('requested_amount'),
         'finance_type_requested': sme.get('finance_type_requested'),
         'date_finance_required': sme.get('date_finance_required'),
         'date_finance_requested': sme.get('date_finance_requested'),
         'finance_term_length': sme.get('finance_term_length'),
-        'guarantor_available': sme.get('guarantor_available'),
         'purpose': sme.get('purpose'),
     }
+    finance_need = _remove_key_if_value_is_none(finance_need)
+    if backfill_required_properties:
+        finance_need = _backfill_required_properties(finance_need, {'requested_amount': 0})
+    return finance_need
+
+
+def sme_v5_to_finance_need_v1_translator(sme):
+    # sme_v5 has additional properties to v3
+    finance_need = sme_v3_to_finance_need_v1_translator(sme)
+    additional_data_from_sme_v5 = {
+        'guarantor_available': sme.get('guarantor_available'),
+    }
+    finance_need.update(additional_data_from_sme_v5)
     return _remove_key_if_value_is_none(finance_need)
 
 
-def sme_v5_to_aggregated_actors_v1_translator(sme):
+def sme_v3_to_aggregated_actors_v1_translator(sme):
     aggregated_actors = {
         'sum_value_of_personal_assets': sme.get('directors_houses'),
         'sum_value_of_property_equity': sme.get('directors_houses'),
         'sum_value_of_pension': sme.get('directors_pensions'),
+    }
+    return _remove_key_if_value_is_none(aggregated_actors)
+
+
+def sme_v5_to_aggregated_actors_v1_translator(sme):
+    # sme_v5 has additional properties to v3
+    aggregated_actors = sme_v3_to_aggregated_actors_v1_translator(sme)
+    additional_data_from_sme_v5 = {
         'max_familiarity_with_financing': sme.get('familiarity_with_financing'),
         'min_personal_credit_rating': sme.get('personal_credit_ratings'),
     }
+    aggregated_actors.update(additional_data_from_sme_v5)
     return _remove_key_if_value_is_none(aggregated_actors)
 
 
@@ -187,7 +259,7 @@ def sme_contact_v3_to_address_v1_translator(sme_contact):
     return _remove_key_if_value_is_none(address)
 
 
-def sme_contact_v3_to_person_v1_translator(sme_contact):
+def sme_contact_v2_to_person_v1_translator(sme_contact, backfill_required_properties=False):
     person = {
         'title': sme_contact.get('applicant_title'),
         'first_name': sme_contact.get('applicant_first_name'),
@@ -199,7 +271,22 @@ def sme_contact_v3_to_person_v1_translator(sme_contact):
     if _dictionary_has_populated_values(address):
         person['addresses'] = [{'address': address}]
 
-    return _remove_key_if_value_is_none(person)
+    person = _remove_key_if_value_is_none(person)
+
+    if backfill_required_properties:
+        person = _backfill_required_properties(person, {'first_name': 'Unknown', 'surname': 'Unknown'})
+
+    telephone = person.get('telephone')
+    if telephone:
+        # Generally, correction to E.164 involves dropping the leading zeros
+        person['telephone'] = re.sub('^0+', '', telephone)
+
+    return person
+
+
+def sme_contact_v3_to_person_v1_translator(sme_contact):
+    # The only difference between sme_contact_v2 and v3 is the requirements
+    return sme_contact_v2_to_person_v1_translator(sme_contact)
 
 
 def _remove_key_if_value_is_none(dictionary):
@@ -207,6 +294,13 @@ def _remove_key_if_value_is_none(dictionary):
         (key, value) for key, value in dictionary.items()
         if value is not None
     )
+
+
+def _backfill_required_properties(object_, backfill_values):
+    for required_property, value in backfill_values.items():
+        if required_property not in object_:
+            object_[required_property] = value
+    return object_
 
 
 def _dictionary_has_populated_values(dictionary):


### PR DESCRIPTION
Chores:
* No longer uses an empty string for first_name or surname when translating sme_contact_v3 to person_v1

Features:
* Supports translating sme_v3 and sme_contact_v2 into finance_application_v3